### PR TITLE
Validación de la función 'clean' añadida en el método 'digitoVerificador'

### DIFF
--- a/src/ChileRut.php
+++ b/src/ChileRut.php
@@ -118,6 +118,12 @@ class ChileRut {
 		//Preparamos el RUT recibido
 		$numero = $this->clean($rut, false);
 
+		// Validamos que el número no sea un 'false' devuelto por la función clean
+		if (!$numero) {
+			// Si es 'false' el RUT es inválido
+			return false;
+		}
+
 		//Calculamos el dígito verificador
 		$txt		= array_reverse(str_split($numero));
 		$sum		= 0;


### PR DESCRIPTION
Esto soluciona un error con los rut de menos de 4 dígitos Ej: 1-9, 12-9.